### PR TITLE
Corregir error de despliegue debido a espacio de Budget insuficiente

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -43,7 +43,7 @@
                 {
                   "type": "initial",
                   "maximumWarning": "500kb",
-                  "maximumError": "1mb"
+                  "maximumError": "2mb"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/default.conf
+++ b/default.conf
@@ -1,0 +1,45 @@
+server {
+    listen       8080;
+    listen  [::]:8080;
+    server_name  localhost;
+
+    #access_log  /var/log/nginx/host.access.log  main;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+        try_files $uri $uri/ /index.html;
+    }
+
+    #error_page  404              /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+
+    # proxy the PHP scripts to Apache listening on 127.0.0.1:80
+    #
+    #location ~ \.php$ {
+    #    proxy_pass   http://127.0.0.1;
+    #}
+
+    # pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+    #
+    #location ~ \.php$ {
+    #    root           html;
+    #    fastcgi_pass   127.0.0.1:9000;
+    #    fastcgi_index  index.php;
+    #    fastcgi_param  SCRIPT_FILENAME  /scripts$fastcgi_script_name;
+    #    include        fastcgi_params;
+    #}
+
+    # deny access to .htaccess files, if Apache's document root
+    # concurs with nginx's one
+    #
+    #location ~ /\.ht {
+    #    deny  all;
+    #}
+}


### PR DESCRIPTION
Al momento del despliegue, es interrumpido por una política del fichero ``angular.json``. Por lo que se ha ampliado la capacidad máxima del Budget en 2MB para evitar dicho error.

Detalles del error:
![image](https://github.com/SEDIX-ES/LotoSpainDispatchWeb/assets/165786947/62bf2f0e-0d77-4101-bfe3-bde930696d1f)

Además, se ha incluido un fichero faltante declarado en el ``dockerfile`` necesario para cambiar los puertos por defecto del servidor web.